### PR TITLE
Create a new module that centralizes and constantifies all URLs used across the add-on, to enable easier test builds with alternative sources

### DIFF
--- a/addon/globalPlugins/addonUpdater/addonHandlerEx.py
+++ b/addon/globalPlugins/addonUpdater/addonHandlerEx.py
@@ -16,6 +16,7 @@ import ssl
 import addonHandler
 import globalVars
 from logHandler import log
+from .urls import URLs
 from . import addonUtils
 addonHandler.initTranslation()
 
@@ -237,7 +238,7 @@ def fetchAddonInfo(info, results, addon, manifestInfo, addonsData):
 		# Therefore spoof the user agent to say this is latest Microsoft Edge.
 		# Source: Stack Overflow, Google searches on Apache/mod_security
 		req = Request(
-			f"https://addons.nvda-project.org/files/get.php?file={addonKey}",
+			f"{URLs.communityFileGetter}{addonKey}",
 			headers={
 				"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.64 Safari/537.36 Edg/101.0.1210.47"  # NOQA: E501
 			}
@@ -259,7 +260,7 @@ def fetchAddonInfo(info, results, addon, manifestInfo, addonsData):
 			return
 	# Note that some add-ons are hosted on community add-ons server directly.
 	if "/" not in addonUrl:
-		addonUrl = f"https://addons.nvda-project.org/files/{addonUrl}"
+		addonUrl = f"{URLs.communityHostedFile}{addonUrl}"
 	# Announce add-on URL for debugging purposes.
 	log.debug(f"nvda3208: add-on URL is {addonUrl}")
 	# Build emulated add-on update dictionary if there is indeed a new version.
@@ -282,12 +283,12 @@ def checkForAddonUpdate(curAddons):
 	def _currentCommunityAddons(results):
 		res = None
 		try:
-			res = urlopen("https://addons.nvda-project.org/files/get.php?addonslist")
+			res = urlopen(URLs.communityAddonsList)
 		except IOError as e:
 			# SSL issue (seen in NVDA Core earlier than 2014.1).
 			if isinstance(e.reason, ssl.SSLCertVerificationError) and e.reason.reason == "CERTIFICATE_VERIFY_FAILED":
 				addonUtils._updateWindowsRootCertificates()
-				res = urlopen("https://addons.nvda-project.org/files/get.php?addonslist")
+				res = urlopen(URLs.communityAddonsList)
 			else:
 				# Inform results dictionary that an error has occurred as this is running inside a thread.
 				log.debug("nvda3208: errors occurred while retrieving community add-ons", exc_info=True)
@@ -301,12 +302,12 @@ def checkForAddonUpdate(curAddons):
 	def _currentCommunityAddonsMetadata(addonsData):
 		res = None
 		try:
-			res = urlopen("https://nvdaaddons.github.io/data/addonsData.json")
+			res = urlopen(URLs.metadata)
 		except IOError as e:
 			# SSL issue (seen in NVDA Core earlier than 2014.1).
 			if isinstance(e.reason, ssl.SSLCertVerificationError) and e.reason.reason == "CERTIFICATE_VERIFY_FAILED":
 				addonUtils._updateWindowsRootCertificates()
-				res = urlopen("https://nvdaaddons.github.io/data/addonsData.json")
+				res = urlopen(URLs.metadata)
 			else:
 				# Clear addon metadata dictionary.
 				log.debug("nvda3208: errors occurred while retrieving community add-ons metadata", exc_info=True)

--- a/addon/globalPlugins/addonUpdater/addonUtils.py
+++ b/addon/globalPlugins/addonUpdater/addonUtils.py
@@ -7,6 +7,7 @@ import ctypes
 import ssl
 import os
 import globalVars
+from .urls import URLs
 
 updateState = {}
 
@@ -74,7 +75,7 @@ def _updateWindowsRootCertificates():
 	crypt = ctypes.windll.crypt32
 	# Get the server certificate.
 	sslCont = ssl._create_unverified_context()
-	u = urlopen("https://addons.nvda-project.org", context=sslCont)
+	u = urlopen(URLs.communitySite, context=sslCont)
 	cert = u.fp._sock.getpeercert(True)
 	u.close()
 	# Convert to a form usable by Windows.

--- a/addon/globalPlugins/addonUpdater/urls.py
+++ b/addon/globalPlugins/addonUpdater/urls.py
@@ -1,0 +1,47 @@
+# urls.py
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2012-2022 NV Access Limited, Beqa Gozalishvili, Joseph Lee, Babbage B.V., Ethan Holliger, Luke Davis
+
+# Centralized URL constants.
+# Primary purpose is to make debugging easier, by allowing test builds to change source locations without effecting main repositories.
+# Secondary purpose is to make it unnecessary to search code when URLs need to be located/updated.
+
+# The _URLAccessors class is a pseudo-singleton that provides property-based accessors.
+# Each self-documenting method returns one URL used by some other part of the add-on.
+# The URLs object is what should be imported by consumers. I.E. "from .urls import URLs"
+# Individual URLs may then be accessed, for example, as: "URLs.communityFileGetter".
+
+class _URLAccessors:
+	"""Public accessors for the URL constants in the urls module."""
+
+	@property
+	def communityFileGetter(self) -> str:
+		"""The portion of the URL before the add-on identifier used to download add-on packages
+		from the nvda-project.org get.php download system.
+		"""
+		return "https://addons.nvda-project.org/files/get.php?file="
+
+	@property
+	def metadata(self) -> str:
+		"""The full URL to the JSON file containing add-ons metadata."""
+		return "https://nvdaaddons.github.io/data/addonsData.json"
+
+	@property
+	def communityHostedFile(self) -> str:
+		"""The base URL for add-on packages that can be downloaded directly from nvda-project.org."""
+		return "https://addons.nvda-project.org/files/"
+
+	@property
+	def communityAddonsList(self) -> str:
+		"""The get.php mechanism provides a list of all add-ons it serves via this URL."""
+		return "https://addons.nvda-project.org/files/get.php?addonslist"
+
+	@property
+	def communitySite(self) -> str:
+		"""The URL to the community add-ons site."""
+		return "https://addons.nvda-project.org"
+
+
+URLs = _URLAccessors()

--- a/buildVars.py
+++ b/buildVars.py
@@ -25,7 +25,7 @@ addon_info = {
 	# Translators: Long description to be shown for this add-on on add-on information from add-ons manager
 	"addon_description": _("""Proof of concept implementation of add-on update feature (NVDA Core issue 3208)"""),
 	# version
-	"addon_version": "22.06",
+	"addon_version": "22.06.1",
 	# Author(s)
 	"addon_author": "Joseph Lee <joseph.lee22590@gmail.com>",
 	# URL for the add-on documentation support


### PR DESCRIPTION
While trying to debug a potential problem, I thought that it might be valuable to change where various things (metadata, add-ons list), are obtained. In looking at those URLs, I noticed that they are written and rewritten in various functions and in two modules.

I thought it would be helpful overall, and for my specific change of sources debugging case, to provide a mechanism to put all of the URLs in one place, where they can be quickly managed.

* I created a urls.py module in the add-on modules folder.
* It contains a private class, with properties returning each URL that was used anywhere in the add-on.
* At its end it creates a URLs object, which will expose those properties to any consumer.
* I modified the modules of the add-on to import that URLs object, and use it to derive the URLs and URL fragments, that are used in various places.

I might have preferred to include and use the immutableKeyObj module that I wrote for the Speech Logger add-on, but this code is more standard and straight forward, though perhaps not as pretty. Can re-visit with that at a later date.
At the moment I just wanted something easy for you to quickly debug and decide upon.